### PR TITLE
feat(benches): shared utils library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bench-utils"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "reqwest",
+ "tokio",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +414,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +449,58 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cookie"
@@ -477,6 +556,70 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -544,6 +687,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "email_address"
@@ -793,6 +942,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1106,6 +1266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1527,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1624,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +1736,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1714,6 +1937,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2040,6 +2272,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2559,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,6 +2658,15 @@ checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/bench-utils/Cargo.toml
+++ b/crates/bench-utils/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "bench-utils"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+reqwest = "0.12"
+criterion = "0.7"
+tokio = { version = "1.48", features = ["rt-multi-thread"] }

--- a/crates/bench-utils/README.md
+++ b/crates/bench-utils/README.md
@@ -1,0 +1,27 @@
+# bench-utils
+
+Shared Criterion helpers for the benches.
+
+## What lives here
+
+- `get_url`: compose a request URL from a env-provided host/port.
+- `start_server` / `stop_server`: spin up a binary via `cargo run --release`
+  and tear it down cleanly once the benchmark finishes.
+- `warm_up_server`: poll an endpoint until the server is ready.
+- `bench_url`: register a Criterion bench that repeatedly issues GET requests.
+
+Centralising these helpers keeps each benchmark focused on the scenario under
+test (e.g. health or work endpoints) instead of duplicating bootstrapping code.
+
+## Typical flow
+
+```text
+1. let mut server = start_server("worker-axum");
+2. let url = get_url("ACTIX_WORKER_ADDRESS", "health");
+3. assert!(warm_up_server(&url, 20, 2)); // retry up to 20 times
+4. bench_url(c, "health", &url);
+5. stop_server(&mut server);
+```
+
+Add `bench-utils` as a dev-dependency in the benchmark crate, import the
+functions you need, and follow the sequence above for any new HTTP benchmark.

--- a/crates/bench-utils/README.md
+++ b/crates/bench-utils/README.md
@@ -8,7 +8,7 @@ Shared Criterion helpers for the benches.
 - `start_server` / `stop_server`: spin up a binary via `cargo run --release`
   and tear it down cleanly once the benchmark finishes.
 - `warm_up_server`: poll an endpoint until the server is ready.
-- `bench_url`: register a Criterion bench that repeatedly issues GET requests.
+- `benchmark_server`: register a Criterion bench that repeatedly issues GET requests.
 
 Centralising these helpers keeps each benchmark focused on the scenario under
 test (e.g. health or work endpoints) instead of duplicating bootstrapping code.
@@ -19,7 +19,7 @@ test (e.g. health or work endpoints) instead of duplicating bootstrapping code.
 1. let mut server = start_server("worker-axum");
 2. let url = get_url("ACTIX_WORKER_ADDRESS", "health");
 3. assert!(warm_up_server(&url, 20, 2)); // retry up to 20 times
-4. bench_url(c, "health", &url);
+4. benchmark_server(c, "health", &url);
 5. stop_server(&mut server);
 ```
 

--- a/crates/bench-utils/src/lib.rs
+++ b/crates/bench-utils/src/lib.rs
@@ -11,25 +11,27 @@
 //! import this crate, call into the helpers, and focus on the benchmarked
 //! request/response logic itself.
 
-use std::{process::{Child, Command, Stdio}, time::Duration};
-use reqwest::Client;
-use tokio::{runtime::Runtime, time::sleep};
 use criterion::Criterion;
+use reqwest::Client;
+use std::{
+    process::{Child, Command, Stdio},
+    time::Duration,
+};
+use tokio::{runtime::Runtime, time::sleep};
 
 /// Compose a benchmark URL from an address stored in an env var.
 ///
 /// The benches set (for example) `WORKER_ADDR=127.0.0.1:4000` before running.
 /// Passing `("WORKER_ADDR", "health")` yields `http://127.0.0.1:4000/health`.
 pub fn get_url(env_key: &str, endpoint: &str) -> String {
-    let address =   std::env::var(env_key)
-        .unwrap_or_else(|_| panic!("Failed to get {}", env_key));
+    let address = std::env::var(env_key).unwrap_or_else(|_| panic!("Failed to get {}", env_key));
     format!("http://{}/{}", address, endpoint)
 }
 
 /// Run a server binary in release mode using Cargo.
 ///
 /// This keeps stdout/stderr quiet so the benchmark output stays clean.
-pub fn start_server(package_name: &str) ->  Child {
+pub fn start_server(package_name: &str) -> Child {
     Command::new("cargo")
         .args(["run", "-p", package_name, "--release"])
         .stdout(Stdio::null())
@@ -66,10 +68,7 @@ pub fn benchmark_server(c: &mut Criterion, id: &str, url: &str) {
         let client = Client::new();
         b.iter(|| {
             rt.block_on(async {
-                let _ = client
-                    .get(url)
-                    .send()
-                    .await;
+                let _ = client.get(url).send().await;
             });
         });
     });

--- a/crates/bench-utils/src/lib.rs
+++ b/crates/bench-utils/src/lib.rs
@@ -3,7 +3,7 @@
 //! The worker benches all follow the same pattern:
 //! 1. Spawn the server binary under test with [`start_server`].
 //! 2. Probe the server until it is ready using [`warm_up_server`].
-//! 3. Drive Criterion against one or more HTTP endpoints via [`bench_url`].
+//! 3. Drive Criterion against one or more HTTP endpoints via [`benchmark_server`].
 //! 4. Tear the server back down with [`stop_server`].
 //!
 //! Keeping these helpers here avoids copy‑pasting the bootstrapping logic
@@ -60,7 +60,7 @@ pub fn warm_up_server(url: &str, retries: u8, timeout: u64) -> bool {
 }
 
 /// Register a Criterion benchmark that repeatedly performs a GET request.
-pub fn bench_url(c: &mut Criterion, id: &str, url: &str) {
+pub fn benchmark_server(c: &mut Criterion, id: &str, url: &str) {
     c.bench_function(id, |b| {
         let rt = Runtime::new().unwrap();
         let client = Client::new();

--- a/crates/bench-utils/src/lib.rs
+++ b/crates/bench-utils/src/lib.rs
@@ -1,0 +1,81 @@
+//! Helper utilities shared across the Criterion benches in this workspace.
+//!
+//! The worker benches all follow the same pattern:
+//! 1. Spawn the server binary under test with [`start_server`].
+//! 2. Probe the server until it is ready using [`warm_up_server`].
+//! 3. Drive Criterion against one or more HTTP endpoints via [`bench_url`].
+//! 4. Tear the server back down with [`stop_server`].
+//!
+//! Keeping these helpers here avoids copy‑pasting the bootstrapping logic
+//! into every benchmark file and makes it easy to introduce new benches—
+//! import this crate, call into the helpers, and focus on the benchmarked
+//! request/response logic itself.
+
+use std::{process::{Child, Command, Stdio}, time::Duration};
+use reqwest::Client;
+use tokio::{runtime::Runtime, time::sleep};
+use criterion::Criterion;
+
+/// Compose a benchmark URL from an address stored in an env var.
+///
+/// The benches set (for example) `WORKER_ADDR=127.0.0.1:4000` before running.
+/// Passing `("WORKER_ADDR", "health")` yields `http://127.0.0.1:4000/health`.
+pub fn get_url(env_key: &str, endpoint: &str) -> String {
+    let address =   std::env::var(env_key)
+        .expect(&format!("Failed to get {}", env_key));
+    format!("http://{}/{}", address, endpoint)
+}
+
+/// Run a server binary in release mode using Cargo.
+///
+/// This keeps stdout/stderr quiet so the benchmark output stays clean.
+pub fn start_server(package_name: &str) ->  Child {
+    Command::new("cargo")
+        .args(&["run", "-p", package_name, "--release"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect(&format!("Failed to start {}", package_name))
+}
+
+/// Poll the server until it responds (or we exhaust retries).
+pub fn warm_up_server(url: &str, retries: u8, timeout: u64) -> bool {
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async {
+        let client = Client::new();
+        for _ in 0..retries {
+            if client
+                .get(url)
+                .timeout(Duration::from_secs(timeout))
+                .send()
+                .await
+                .is_ok()
+            {
+                return true;
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+        false
+    })
+}
+
+/// Register a Criterion benchmark that repeatedly performs a GET request.
+pub fn bench_url(c: &mut Criterion, id: &str, url: &str) {
+    c.bench_function(id, |b| {
+        let rt = Runtime::new().unwrap();
+        let client = Client::new();
+        b.iter(|| {
+            rt.block_on(async {
+                let _ = client
+                    .get(url)
+                    .send()
+                    .await;
+            });
+        });
+    });
+}
+
+/// Stop the spawned server that was started via [`start_server`].
+pub fn stop_server(server: &mut Child) {
+    let _ = server.kill().expect("Failed to kill server");
+}

--- a/crates/bench-utils/src/lib.rs
+++ b/crates/bench-utils/src/lib.rs
@@ -22,7 +22,7 @@ use criterion::Criterion;
 /// Passing `("WORKER_ADDR", "health")` yields `http://127.0.0.1:4000/health`.
 pub fn get_url(env_key: &str, endpoint: &str) -> String {
     let address =   std::env::var(env_key)
-        .expect(&format!("Failed to get {}", env_key));
+        .unwrap_or_else(|_| panic!("Failed to get {}", env_key));
     format!("http://{}/{}", address, endpoint)
 }
 
@@ -31,11 +31,11 @@ pub fn get_url(env_key: &str, endpoint: &str) -> String {
 /// This keeps stdout/stderr quiet so the benchmark output stays clean.
 pub fn start_server(package_name: &str) ->  Child {
     Command::new("cargo")
-        .args(&["run", "-p", package_name, "--release"])
+        .args(["run", "-p", package_name, "--release"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .expect(&format!("Failed to start {}", package_name))
+        .unwrap_or_else(|_| panic!("Failed to start {}", package_name))
 }
 
 /// Poll the server until it responds (or we exhaust retries).
@@ -77,5 +77,5 @@ pub fn bench_url(c: &mut Criterion, id: &str, url: &str) {
 
 /// Stop the spawned server that was started via [`start_server`].
 pub fn stop_server(server: &mut Child) {
-    let _ = server.kill().expect("Failed to kill server");
+    let _ = server.kill();
 }


### PR DESCRIPTION
# Shared Bench utilities

This  change adds a new library in the workspace containing reusable functions to run benches with ease and avoid duplication:

## Starting/Stopping a binary

- Use std::process::Command to run a crate by its name to return an Child process object
- Kill the child process object

## Warm up a server

- Accept an URL, a number of retries and a timeout per retry to indicate readiness.

## Benchmark a server

- Use a reference to a criterion object, the  benchmark name and the target URL to iterate on calling the endpoint